### PR TITLE
#167765408 Remember user information for future requests

### DIFF
--- a/public/api-docs/swaggerDoc.json
+++ b/public/api-docs/swaggerDoc.json
@@ -283,6 +283,42 @@
                     }
                 }
             }
+        },
+        "/api/v1/auth/remember-info": {
+            "patch": {
+                "tags": [
+                    "User"
+                ],
+                "summary": "user remember info",
+                "description": "Allows a user to remember his info for future requests",
+                "operationId": "rememberInfo",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "in": "body",
+                        "name": "user",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "rememberInfo": {
+                                    "type": "string",
+                                    "example": true
+                                }
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/Success"
+                        }
+                    }
+                }
+            }
         }
     },
     "securityDefinitions": {
@@ -357,6 +393,18 @@
             },
             "xml": {
                 "name": "User"
+            }
+        },
+        "Success": {
+            "type": "object",
+            "properties": {
+                "status": {
+                    "type": "string",
+                    "description": "success"
+                }
+            },
+            "xml": {
+                "name": "Success"
             }
         },
         "externalDocs": {

--- a/src/controllers/UserController.js
+++ b/src/controllers/UserController.js
@@ -11,7 +11,7 @@ const redirect = process.env.LINKENDIN_REDIRECT_URL;
 const Linkedin = Linkedn(clientId, clientSecret, redirect);
 
 
-const { resSuccess, resError } = ResponseMsg;
+const { resSuccess, resSuccessShort, resError } = ResponseMsg;
 /**
  * User controller Class
  */
@@ -162,5 +162,23 @@ export default class UserController {
       });
       profileRequest.end();
     });
+  }
+
+  /**
+   * @name rememberInfo
+   * @param {*} req Request object
+   * @param {*} res Response object
+   * @return {json} Returns json object
+   * @memberof User
+   */
+  static async rememberInfo(req, res) {
+    const { id } = req.user;
+    const { rememberInfo } = req.body;
+    try {
+      await UserServices.UpdateRememberInfo(id, rememberInfo);
+      return resSuccessShort(res, 200);
+    } catch (error) {
+      return resError(res, 500, error.message);
+    }
   }
 }

--- a/src/database/migrations/20190827125917-create-user.js
+++ b/src/database/migrations/20190827125917-create-user.js
@@ -40,6 +40,14 @@ module.exports = {
       type: Sequelize.BOOLEAN,
       defaultValue: false,
     },
+    rememberInfo: {
+      allowNull: true,
+      type: Sequelize.BOOLEAN,
+      defaultValue: false,
+      validate: {
+        notNull: true,
+      },
+    },
     createdAt: {
       allowNull: false,
       type: Sequelize.DATE,

--- a/src/models/user.js
+++ b/src/models/user.js
@@ -27,6 +27,11 @@ export default (sequelize, DataTypes) => {
       type: DataTypes.DATE,
       defaultValue: sequelize.fn('NOW')
     },
+    rememberInfo: {
+      allowNull: true,
+      type: DataTypes.BOOLEAN,
+      defaultValue: false,
+    },
     phoneNumber: {
       allowNull: true,
       type: DataTypes.STRING

--- a/src/routes/userRoutes.js
+++ b/src/routes/userRoutes.js
@@ -14,14 +14,16 @@ const {
   getGoogleAccountFromCode,
   getLinkedinUrl,
   getLinkedinAccountFromCode,
+  rememberInfo,
 } = UserController;
 
 const { checkUserExists, checkUserExistBeforeLogin } = UserMiddlewares;
-const { emailValidation, userLoginValidation } = userValidations;
+const { emailValidation, userLoginValidation, rememberInfoValidation } = userValidations;
 const { verifyToken } = Auth;
 
 userRoutes.post('/signup', verifyToken, emailValidation, validationHandler, checkUserExists, createUser);
 userRoutes.post('/signin', userLoginValidation, validationHandler, checkUserExistBeforeLogin, login);
+userRoutes.patch('/remember-info', verifyToken, rememberInfoValidation, validationHandler, rememberInfo);
 
 userRoutes.get('/user/google/signin', getGoogleUrl);
 userRoutes.get('/google/callback', getGoogleAccountFromCode);

--- a/src/services/userServices.js
+++ b/src/services/userServices.js
@@ -26,4 +26,16 @@ export default class UserServices {
     const data = await models.User.findOne({ where: { email } });
     return data;
   }
+
+  /**
+   * @name UpdateRememberInfo
+   * @description Updates the remember info column in the user's table
+   * @param { string } id the user's id
+   * @param { object } rememberInfo the field to be updated with the value
+   * @returns {object} return the user's data
+   */
+  static async UpdateRememberInfo(id, rememberInfo) {
+    const data = await models.User.update({ rememberInfo }, { where: { id } });
+    if (data[0] === 0) throw new Error('could not update user field');
+  }
 }

--- a/src/tests/routes/userSpec.js
+++ b/src/tests/routes/userSpec.js
@@ -167,3 +167,20 @@ describe('GET /api/v1/user/linkedin/signin', () => {
       });
   });
 });
+describe('PATCH /api/v1/auth/remember-info', () => {
+  it('should allow a user opt for saving profile information for future requests', (done) => {
+    const data = {
+      rememberInfo: false,
+    };
+    chai
+      .request(app)
+      .patch(`${endPoint}/auth/remember-info`)
+      .set('Authorization', token)
+      .send(data)
+      .end((_err, res) => {
+        expect(res).to.have.status(200);
+        expect(res.body.status).to.be.equal('success');
+        done();
+      });
+  });
+});

--- a/src/utils/responseMessages.js
+++ b/src/utils/responseMessages.js
@@ -33,5 +33,19 @@ class ResponseMsg {
       data,
     });
   }
+
+  /**
+     * response
+     * @param { Object } res
+     * @param { Number } status
+     * @returns { Object } response body
+     * @description defines the standard response format when a data object is to be returned
+     * @memberof ResponseMsg
+     */
+  static resSuccessShort(res, status) {
+    return res.status(status).json({
+      status: 'success',
+    });
+  }
 }
 export default ResponseMsg;

--- a/src/validation/userValidation.js
+++ b/src/validation/userValidation.js
@@ -34,4 +34,12 @@ const emailValidation = [
   check('email').normalizeEmail(),
 ];
 
-export default { emailValidation, userValidation, userLoginValidation };
+const rememberInfoValidation = [
+  check('rememberInfo').trim().not().isEmpty()
+    .withMessage('rememberInfo field cannot be empty'),
+  check('rememberInfo').isBoolean().withMessage('rememberInfo should be a boolean'),
+];
+
+export default {
+  emailValidation, userValidation, userLoginValidation, rememberInfoValidation
+};


### PR DESCRIPTION
## What does this PR do?
- Ensures that a users information is auto filled for future requests, if the user choses this option

## Description of Task to be completed?
- create a remember info column in the user table that takes true or false
- create a patch route to update this column 
- write tests and update swagger

## How should this be manually tested?
- clone this branch
- Run npm run install
- Run npm test to run tests
- send a PATCH request to /v1/auth/remember-info with token attached
- review app link - https://phoenix-bn-backend-stagi-pr-37.herokuapp.com/api/v1/remember-info
```
sample body:

{
    "rememberInfo":"true"
}
```


## What are the relevant pivotal tracker stories?
- #167765408

## Implementation Plan Document
